### PR TITLE
Fix for manifest to put openLinkUrlPrefixes as property of gmail

### DIFF
--- a/Full-application/appsscript.json
+++ b/Full-application/appsscript.json
@@ -13,11 +13,9 @@
     "contextualTriggers": [{
       "unconditional": {
       },
-      "onTriggerFunction": "getContextualAddOn",
-      "openLinkUrlPrefixes": [
-          "https://docs.google.com/"
-      ],
+      "onTriggerFunction": "getContextualAddOn"
     }],
+    "openLinkUrlPrefixes": ["https://docs.google.com/"],
     "primaryColor": "#41f470",
     "secondaryColor": "#94f441"
   }


### PR DESCRIPTION
The manifest for Full-application has openLinkUrlPrefixes as child of  gmail.contextualTriggers.openLinkUrlPrefixes[] where it shoud be gmail.openLinkUrlPrefixes[]